### PR TITLE
fix(prepare.js): allow-same-version

### DIFF
--- a/lib/prepare.js
+++ b/lib/prepare.js
@@ -3,7 +3,7 @@ const execa = require('execa');
 module.exports = async (pluginConfig, {cwd, env, stdout, stderr, nextRelease: {version}, logger}) => {
   logger.log(`Write version ${version} to package.json`);
 
-  const versionResult = execa('npm', ['version', version, '--no-git-tag-version'], {cwd, env});
+  const versionResult = execa('npm', ['version', version, '--no-git-tag-version', '--allow-same-version'], {cwd, env});
   versionResult.stdout.pipe(
     stdout,
     {end: false}

--- a/test/prepare.test.js
+++ b/test/prepare.test.js
@@ -38,6 +38,31 @@ test('Updade package.json', async t => {
   t.is(t.context.log.args[0][0], 'Write version 1.0.0 to package.json');
 });
 
+// Test corner case of version in package,json being identical to last tag
+test('Allow same version', async t => {
+  const cwd = tempy.directory();
+  const packagePath = path.resolve(cwd, 'package.json');
+  await outputJson(packagePath, {version: '0.0.0-dev'});
+
+  await prepare(
+    {},
+    {
+      cwd,
+      env: {},
+      stdout: t.context.stdout,
+      stderr: t.context.stderr,
+      nextRelease: {version: '0.0.0-dev'},
+      logger: t.context.logger,
+    }
+  );
+
+  // Verify package.json has been updated
+  t.is((await readJson(packagePath)).version, '0.0.0-dev');
+
+  // Verify the logger has been called with the version updated
+  t.is(t.context.log.args[0][0], 'Write version 0.0.0-dev to package.json');
+});
+
 test('Updade package.json and npm-shrinkwrap.json', async t => {
   const cwd = tempy.directory();
   const packagePath = path.resolve(cwd, 'package.json');


### PR DESCRIPTION
see eXist-db/atom-existdb#45
this fixes a corner case in which a successfully published git-tag is identical with the version-string for the published apm package.

This behaviour occurs when following the docs and e.g.  having the github plugin executed before the apm plugin see e.g. [this run](https://travis-ci.com/eXist-db/atom-existdb/jobs/172651276#L617)

I also added a test